### PR TITLE
Fix formset check and enable double opt in

### DIFF
--- a/addons/Mailchimp/MailchimpListener.php
+++ b/addons/Mailchimp/MailchimpListener.php
@@ -34,8 +34,10 @@ class MailchimpListener extends Listener
      */
     public function formSubmission($submission)
     {
+        $formsets = collect($this->getConfig('formsets'));
+        
         // only do something if we're on the right formset
-        if (Helper::ensureArray(array_has($this->getConfig('formsets'), $submission->formset()->name())))
+        if ($formsets->contains($submission->formset()->name()))
         {
             try
             {

--- a/addons/Mailchimp/MailchimpListener.php
+++ b/addons/Mailchimp/MailchimpListener.php
@@ -64,7 +64,7 @@ class MailchimpListener extends Listener
 
         $mailchimp->post('lists/' . $list . '/members', [
             'email_address' => $email,
-            'status'        => 'subscribed',
+            'status'        => $this->getConfigBool('double_opt_in', true) ? 'pending' : 'subscribed',
         ]);
 
         if (!$mailchimp->success()) {


### PR DESCRIPTION
Excuse the two-in-one PR.

First, fix how you're checking if the submitted formset is in the configured list.

The `array_has` helper was checking if an array has a given key. We need to check if the value exists. The Collection `contains` method does this.

Second part is the double opt in feature.

When you subscribe, you will get an email from Mailchimp confirming your subscription.
Currently, you could enter anyone's email and it would subscribe them.

If you're evil or really need to disable this for some reason, you can by adding `double_opt_in: false` to `mailchimp.yaml`.